### PR TITLE
Fixed a typo in readme file

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -17,8 +17,8 @@
     Pipedrive::Organization.create( params )
     Pipedrive::Organization.find( <ID> )
 
-    Pipdrive::Person.create( params )
-    Pipdrive::Person.find( <ID >)
+    Pipedrive::Person.create( params )
+    Pipedrive::Person.find( <ID >)
 
 
 == Contributing to pipedrive-ruby


### PR DESCRIPTION
I just noticed this typo, I've lost 30 minutes trying to figure out why isn't pipedrive required... :)
