### PR TITLE
Fix Pipedrive::Stage.deals

### DIFF
--- a/lib/pipedrive/stage.rb
+++ b/lib/pipedrive/stage.rb
@@ -1,7 +1,7 @@
 module Pipedrive
   class Stage < Base
     def self.deals(id)
-      Deal.all(get "#{resource_path}/#{id}/deals", :everyone => 1)
+      Deal.all(get "#{resource_path}/#{id}/deals", :query => {:everyone => 1})
     end
   end
 end


### PR DESCRIPTION
Correctly provide the get parameters, otherwise just the deals of the current user will be returned.
