### PR TITLE
Add `absolutely_all` short-hand method

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -98,6 +98,10 @@ module Pipedrive
         end
       end
 
+      def absolutely_all(options = {})
+        self.all(nil, options, true)
+      end
+
       def create( opts = {} )
         res = post resource_path, :body => opts
         if res.success?

--- a/pipedrive-ruby.gemspec
+++ b/pipedrive-ruby.gemspec
@@ -5,11 +5,11 @@
 
 Gem::Specification.new do |s|
   s.name = "pipedrive-ruby"
-  s.version = "0.3.3"
+  s.version = "0.3.4"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["Jan Schwenzien", "Waldemar Kusnezow", "Joel Courtney"]
-  s.date = "2014-04-23"
+  s.authors = ["Jan Schwenzien", "Waldemar Kusnezow", "Joel Courtney", "Ryan Faerman"]
+  s.date = "2014-06-26"
   s.description = "Ruby wrapper for the Pipedrive API"
   s.email = "jan@general-scripting.com"
   s.extra_rdoc_files = [


### PR DESCRIPTION
I'm finding myself frequently needing entire datasets and invoking the `all` method as `.all(nil, {}, true)` which is obtuse.

I've provided a simple method with those options predefined to provide clarity to my codebase.
