### PR TITLE
Typo in variable name corrected

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -94,7 +94,7 @@ module Pipedrive
           end
           data
         else
-          bad_response(res,attrs)
+          bad_response(res,options)
         end
       end
 


### PR DESCRIPTION
On bad response the library will raise a name error exception due to a typo in variable name:

```
NameError: undefined local variable or method `attrs' for Pipedrive::Person:Class
  lib/pipedrive/base.rb:97:in `all`
```
