### PR TITLE
http -> https

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -16,7 +16,7 @@ module Pipedrive
 
     include HTTParty
     
-    base_uri 'api.pipedrive.com/v1'
+    base_uri 'https://api.pipedrive.com/v1'
     headers HEADERS
     format :json
 


### PR DESCRIPTION
Today Pipedrive had some issues with HTTP API requests.
Also Pipedrive suggests using HTTPS instead of HTTP
