### PR TITLE
Removed a `puts` from Pipedrive::Base

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -73,7 +73,6 @@ module Pipedrive
       #
       # @param [HTTParty::Response] response
       def bad_response(response, params={})
-        puts params.inspect
         if response.class == HTTParty::Response
           raise HTTParty::ResponseError, response
         end


### PR DESCRIPTION
This caused some unnecesary output in logs.
