### PR TITLE
added delete activity endpoint

### DIFF
--- a/lib/pipedrive/activity.rb
+++ b/lib/pipedrive/activity.rb
@@ -1,4 +1,10 @@
 module Pipedrive
   class Activity < Base
+
+    def delete_activity activity_id
+      res = delete "#{resource_path}/#{id}", { :body => { :id => activity_id } }
+      res.success? ? nil : bad_response(res,activity_id)
+    end
+
   end
 end


### PR DESCRIPTION
There was no way to delete activities, even though the api supports it. So, I added a method to handle activity deletion.
