### PR TITLE
Add #destroy to pipedrive/base

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -117,6 +117,11 @@ module Pipedrive
         res = get "#{resource_path}/find", :query => { :term => name }.merge(opts)
         res.ok? ? new_list(res) : bad_response(res,{:name => name}.merge(opts))
       end
+      
+      def destroy
+        res = delete "#{resource_path}/#{id}"
+        res.ok? ? res : bad_response(res, attrs)
+      end
 
       def resource_path
         # The resource path should match the camelCased class name with the


### PR DESCRIPTION
An easy way to delete items via ruby api. 

No tests though. I'm using almost the same code for deals, organizations, contacts etc and it works. 

I can see a situation this backfires: trying to remove a person /w associated activities on him will result in an error and we should either support force: true, or return a relevant message.

But still, returning `bad_response` will give sufficient information. That't a good first step, right? 
