### PR TITLE
Change base_uri to use HTTPS instead of HTTP

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -16,7 +16,7 @@ module Pipedrive
 
     include HTTParty
     
-    base_uri 'api.pipedrive.com/v1'
+    base_uri 'https://api.pipedrive.com/v1'
     headers HEADERS
     format :json
 


### PR DESCRIPTION
Pipedrive will deprecate HTTP API access on May 11, 2015.
