### PR TITLE
Use HTTPS in all requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
       git (>= 1.2.5)
       rake
       rdoc
-    json (1.7.7)
+    json (1.8.2)
     metaclass (0.0.1)
     mime-types (1.24)
     mocha (0.10.5)

--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -15,8 +15,8 @@ module Pipedrive
   class Base < OpenStruct
 
     include HTTParty
-    
-    base_uri 'api.pipedrive.com/v1'
+
+    base_uri 'https://api.pipedrive.com/v1'
     headers HEADERS
     format :json
 
@@ -107,7 +107,7 @@ module Pipedrive
           bad_response(res,opts)
         end
       end
-      
+
       def find(id)
         res = get "#{resource_path}/#{id}"
         res.ok? ? new(res) : bad_response(res,id)

--- a/test/test_pipedrive_authentication.rb
+++ b/test/test_pipedrive_authentication.rb
@@ -9,7 +9,7 @@ class TestPipedriveAuthentication < Test::Unit::TestCase
   should "send authentication token with each request" do
     Pipedrive.authenticate("some-token")
 
-    stub_request(:get, "http://api.pipedrive.com/v1/?api_token=some-token").
+    stub_request(:get, "https://api.pipedrive.com/v1/?api_token=some-token").
       with(:headers => {
         'Accept'=>'application/json',
         'Content-Type'=>'application/x-www-form-urlencoded',

--- a/test/test_pipedrive_deal.rb
+++ b/test/test_pipedrive_deal.rb
@@ -13,7 +13,7 @@ class TestPipedriveDeal < Test::Unit::TestCase
       "value" => "37k"
     }
 
-    stub_request(:post, "http://api.pipedrive.com/v1/deals?api_token=some-token").
+    stub_request(:post, "https://api.pipedrive.com/v1/deals?api_token=some-token").
       with(:body => body,
         :headers => {
           'Accept'=>'application/json',

--- a/test/test_pipedrive_note.rb
+++ b/test/test_pipedrive_note.rb
@@ -13,7 +13,7 @@ class TestPipedriveNote < Test::Unit::TestCase
       # deal_id
     }
 
-    stub_request(:post, "http://api.pipedrive.com/v1/notes?api_token=some-token").
+    stub_request(:post, "https://api.pipedrive.com/v1/notes?api_token=some-token").
       with(:body => body, :headers => {
           'Accept'=>'application/json',
           'Content-Type'=>'application/x-www-form-urlencoded',

--- a/test/test_pipedrive_organization.rb
+++ b/test/test_pipedrive_organization.rb
@@ -6,7 +6,7 @@ class TestPipedriveOrganization < Test::Unit::TestCase
   end
 
   should "execute a valid person request" do
-    stub_request(:post, "http://api.pipedrive.com/v1/organizations?api_token=some-token").
+    stub_request(:post, "https://api.pipedrive.com/v1/organizations?api_token=some-token").
       with(:body => {
           "name" => "Dope.org"
         },

--- a/test/test_pipedrive_person.rb
+++ b/test/test_pipedrive_person.rb
@@ -13,7 +13,7 @@ class TestPipedrivePerson < Test::Unit::TestCase
       "phone"=>["0123456789"]
     }
 
-    stub_request(:post, "http://api.pipedrive.com/v1/persons?api_token=some-token").
+    stub_request(:post, "https://api.pipedrive.com/v1/persons?api_token=some-token").
       with(:body => body, :headers => {
           'Accept'=>'application/json',
           'Content-Type'=>'application/x-www-form-urlencoded',


### PR DESCRIPTION
This fixes the Pipedrive deprecation that no longer allows HTTP requests
