### PR TITLE
HTTP is deprecated. Must use HTTPS.

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -16,7 +16,7 @@ module Pipedrive
 
     include HTTParty
     
-    base_uri 'api.pipedrive.com/v1'
+    base_uri 'https://api.pipedrive.com/v1'
     headers HEADERS
     format :json
 


### PR DESCRIPTION
http://blog.pipedrive.com/2015/04/deprecating-http-non-secure-api-access-from-may-11-2015/

I especially like the part where they didn't e-mail me to let me know before it broke! :-1: 
