### PR TITLE
HTTPS support and explicit update failure reporting

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -16,7 +16,7 @@ module Pipedrive
 
     include HTTParty
     
-    base_uri 'api.pipedrive.com/v1'
+    base_uri 'https://api.pipedrive.com/v1'
     headers HEADERS
     format :json
 

--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -15,7 +15,7 @@ module Pipedrive
   class Base < OpenStruct
 
     include HTTParty
-    
+
     base_uri 'https://api.pipedrive.com/v1'
     headers HEADERS
     format :json
@@ -49,14 +49,22 @@ module Pipedrive
     #
     # @param [Hash] opts
     # @return [Boolean]
-    def update(opts = {})
+    def update(opts = {}, raise_error=false)
       res = put "#{resource_path}/#{id}", :body => opts
       if res.success?
         res['data'] = Hash[res['data'].map {|k, v| [k.to_sym, v] }]
         @table.merge!(res['data'])
       else
-        false
+        if raise_error
+          raise StandardError.new("update to #{resource_path}/#{id} failed with #{res.code} #{res.message} #{res.body}")
+        else
+          false
+        end
       end
+    end
+
+    def update!(opts = {})
+      update(opts, true)
     end
 
     class << self
@@ -107,7 +115,7 @@ module Pipedrive
           bad_response(res,opts)
         end
       end
-      
+
       def find(id)
         res = get "#{resource_path}/#{id}"
         res.ok? ? new(res) : bad_response(res,id)

--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -126,6 +126,11 @@ module Pipedrive
         res.ok? ? new_list(res) : bad_response(res,{:name => name}.merge(opts))
       end
 
+      def find_with_options(opts = { start: 0 })
+        res = get "#{resource_path}", query: opts
+        res.ok? ? new_list(res) : bad_response(res,opts)
+      end
+
       def resource_path
         # The resource path should match the camelCased class name with the
         # first letter downcased.  Pipedrive API is sensitive to capitalisation

--- a/lib/pipedrive/deal.rb
+++ b/lib/pipedrive/deal.rb
@@ -9,7 +9,7 @@ module Pipedrive
     def products
       Product.all(get "#{resource_path}/#{id}/products")
     end
-    
+
     def remove_product product_attachment_id
       res = delete "#{resource_path}/#{id}/products", { :body => { :product_attachment_id => product_attachment_id } }
       res.success? ? nil : bad_response(res,product_attachment_id)
@@ -26,6 +26,5 @@ module Pipedrive
     def notes(opts = {:sort_by => 'add_time', :sort_mode => 'desc'})
       Note.all( get("/notes", :query => opts.merge(:deal_id => id) ) )
     end
-    
   end
 end


### PR DESCRIPTION
Couple of minor amends to 
1. resolve #30
2. add an overload to `Base#update` called `Base#update!` to allow it to raise and report an exception when an update fails, making debugging far simpler
