### PR TITLE
Bigfix: use options for bad_response-method and not attr

### DIFF
--- a/lib/pipedrive/base.rb
+++ b/lib/pipedrive/base.rb
@@ -94,7 +94,7 @@ module Pipedrive
           end
           data
         else
-          bad_response(res,attrs)
+          bad_response(res, options)
         end
       end
 


### PR DESCRIPTION
reason: NameError: undefined local variable or method `attrs`
